### PR TITLE
Update sample_nu0.0.ini

### DIFF
--- a/camb_data/sample_nu0.0.ini
+++ b/camb_data/sample_nu0.0.ini
@@ -19,13 +19,12 @@ l_max_tensor       = 1500
 k_eta_max_tensor   = 3000
 
 # Standard cosmological parameters
-use_physical         = F
 hubble               = 67.1
 w                    = -1
-omega_baryon         = 0.049
-omega_cdm            = 0.2685
-omega_lambda         = 0.6825
-omega_neutrino       = 0.0
+ombh2                = 0.049
+omch2                = 0.2685
+omk                  = 0.6825
+omnuh2               = 0.0
 
 # Massive neutrino parameters
 massive_nu_approx    = 1


### PR DESCRIPTION
Sample camb parameter files are not compatible with the new CAMB versions.
1.  use_physical is deprecated
2. Some parameters are contracted