### PR TITLE
Pull request for standalone SimplePofk - 26.06.2021 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MG-PICOLA-PUBLIC
+V# MG-PICOLA-PUBLIC
 MG-PICOLA v0.9, May 2017
 Author: Hans A. Winther
 
@@ -40,7 +40,7 @@ This code is based on the [L-PICOLA](https://github.com/CullanHowlett/l-picola) 
  
  - Added the TSC mass-assignment scheme in SimplePofk.
 
- - Changed the normalization of the output in SimplePofk, the changes wrt. the previous version are (2i-1)M_PI/BoxSize for wavelength (previously just i) and multiplication by (BoxSize)^3 for P(k).
+ - Changed the normalization of the output in SimplePofk, the changes wrt. the previous version are (2i+1)M_PI/BoxSize for wavelength (previously just i) and multiplication by (BoxSize)^3 for P(k).
 
  - Added the automatic endianness check and byte change for GADGET files. 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This code is based on the [L-PICOLA](https://github.com/CullanHowlett/l-picola) 
  
  - Added the TSC mass-assignment scheme in SimplePofk
 
- - Changed the normalization of the output in SimplePofk, the multiplicatory factors wrt. the previous version are (2*i-1)/L for wavelength and Pi*(NGRID)^3 for P(k)
+ - Changed the normalization of the output in SimplePofk, the multiplicatory factors wrt. the previous version are (2i-1)/L for wavelength and Pi*(NGRID)^3 for P(k)
 
 
 MG-PICOLA is distributed under the GNU Public License v3 (see COPYING for details).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ This code is based on the [L-PICOLA](https://github.com/CullanHowlett/l-picola) 
  
  - Added the TSC mass-assignment scheme in SimplePofk
 
- - Changed the normalization of the output in SimplePofk, the multiplicatory factors wrt. the previous version are (2i-1)/L for wavelength and Pi*(NGRID)^3 for P(k)
+ - Changed the normalization of the output in SimplePofk, the multiplicatory factors wrt. the previous version are (2i-1)*M_PI/L for wavelength and Pi*(L)^3 for P(k)
 
+ - Added the automatic endianness check and byte change for GADGET files 
+
+ - Slightly changed the reading routine of single versus multiple chunks of Gadget data. If the simulation is in one single file (SimplePofk argument NumFiles being 1), the basename serves as the name for the opened file. Otherwise, the previous routine applies.
+
+ - Added a preprocessor option for switching the units to kpc/h
 
 MG-PICOLA is distributed under the GNU Public License v3 (see COPYING for details).

--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ This code is based on the [L-PICOLA](https://github.com/CullanHowlett/l-picola) 
 
  - Added support for amplitude fixed (|delta(k)|^2 == P(k)) and inverted (delta -> -delta) initial conditions (see Pontzen et al. 2016). This can dramatically reduce the sample variance in P(k) (and other observables) by running pairs of simulation (normal and inverted) and adding the resulting P(k). See e.g. [1806.01871](https://arxiv.org/pdf/1806.01871.pdf) which shows that this procedure is bias free.
  
- - For SimplePofk, changed the types of indexing variables so that overflow no longer occurs for NGRID >= 1290 (overflow of int type)
+ - For SimplePofk, changed the types of indexing variables so that overflow no longer occurs for NGRID >= 1290 (overflow of int type).
  
- - Added the TSC mass-assignment scheme in SimplePofk
+ - Added the TSC mass-assignment scheme in SimplePofk.
 
- - Changed the normalization of the output in SimplePofk, the multiplicatory factors wrt. the previous version are (2i-1)*M_PI/L for wavelength and Pi*(L)^3 for P(k)
+ - Changed the normalization of the output in SimplePofk, the changes wrt. the previous version are (2i-1)M_PI/BoxSize for wavelength (previously just i) and multiplication by (BoxSize)^3 for P(k).
 
- - Added the automatic endianness check and byte change for GADGET files 
+ - Added the automatic endianness check and byte change for GADGET files. 
 
  - Slightly changed the reading routine of single versus multiple chunks of Gadget data. If the simulation is in one single file (SimplePofk argument NumFiles being 1), the basename serves as the name for the opened file. Otherwise, the previous routine applies.
 
- - Added a preprocessor option for switching the units to kpc/h
+ - Added a preprocessor option for switching the units to kpc/h.
 
 MG-PICOLA is distributed under the GNU Public License v3 (see COPYING for details).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-V# MG-PICOLA-PUBLIC
+# MG-PICOLA-PUBLIC
 MG-PICOLA v0.9, May 2017
 Author: Hans A. Winther
 

--- a/README.md
+++ b/README.md
@@ -35,5 +35,12 @@ This code is based on the [L-PICOLA](https://github.com/CullanHowlett/l-picola) 
  - Added memory monitoring (using wrappers around malloc and free).
 
  - Added support for amplitude fixed (|delta(k)|^2 == P(k)) and inverted (delta -> -delta) initial conditions (see Pontzen et al. 2016). This can dramatically reduce the sample variance in P(k) (and other observables) by running pairs of simulation (normal and inverted) and adding the resulting P(k). See e.g. [1806.01871](https://arxiv.org/pdf/1806.01871.pdf) which shows that this procedure is bias free.
+ 
+ - For SimplePofk, changed the types of indexing variables so that overflow no longer occurs for NGRID >= 1290 (overflow of int type)
+ 
+ - Added the TSC mass-assignment scheme in SimplePofk
+
+ - Changed the normalization of the output in SimplePofk, the multiplicatory factors wrt. the previous version are (2*i-1)/L for wavelength and Pi*(NGRID)^3 for P(k)
+
 
 MG-PICOLA is distributed under the GNU Public License v3 (see COPYING for details).

--- a/SimplePofk/Makefile
+++ b/SimplePofk/Makefile
@@ -11,9 +11,6 @@ OPTIONS = -D_SUBTRACTSHOTNOISE -D_NGP
 #-D_UNITS
 
 # Path to FFTW library
-#I = -I/home/topolski/include
-#L = -L/home/topolski/lib -lfftw3 -lfftw3_threads
-
 I = -I$(HOME)/include
 L = -L$(HOME)/lib -lfftw3 -lfftw3_threads
 

--- a/SimplePofk/Makefile
+++ b/SimplePofk/Makefile
@@ -1,14 +1,17 @@
 SHELL := /bin/bash
 
 # Set compiler
-CC = g++-mp-6
+CC = g++
 
 # Options
-OPTIONS = -D_SUBTRACTSHOTNOISE -D_CIC
+# Choose among mass-assignment functions using -D_FUNCTION, where FUNCTION = NGP, CIC or TSC 
+# If the input Gadget data is in kpc/h, use -D_UNITS, otherwise it is assumed that it is already in Mpc/h
+
+OPTIONS = -D_SUBTRACTSHOTNOISE -D_NGP -D_UNITS
 
 # Path to FFTW library
-I = -I$(HOME)/local/include
-L = -L$(HOME)/local/lib -lfftw3 -lfftw3_threads
+I = -I/home/topolski/include
+L = -L/home/topolski/lib -lfftw3 -lfftw3_threads
 
 C = -O3 -Wall -fopenmp $(OPTIONS)
 

--- a/SimplePofk/Makefile
+++ b/SimplePofk/Makefile
@@ -11,8 +11,11 @@ OPTIONS = -D_SUBTRACTSHOTNOISE -D_NGP
 #-D_UNITS
 
 # Path to FFTW library
-I = -I/home/topolski/include
-L = -L/home/topolski/lib -lfftw3 -lfftw3_threads
+#I = -I/home/topolski/include
+#L = -L/home/topolski/lib -lfftw3 -lfftw3_threads
+
+I = -I$(HOME)/include
+L = -L$(HOME)/lib -lfftw3 -lfftw3_threads
 
 C = -O3 -Wall -fopenmp $(OPTIONS)
 

--- a/SimplePofk/Makefile
+++ b/SimplePofk/Makefile
@@ -7,7 +7,8 @@ CC = g++
 # Choose among mass-assignment functions using -D_FUNCTION, where FUNCTION = NGP, CIC or TSC 
 # If the input Gadget data is in kpc/h, use -D_UNITS, otherwise it is assumed that it is already in Mpc/h
 
-OPTIONS = -D_SUBTRACTSHOTNOISE -D_NGP -D_UNITS
+OPTIONS = -D_SUBTRACTSHOTNOISE -D_NGP
+#-D_UNITS
 
 # Path to FFTW library
 I = -I/home/topolski/include

--- a/SimplePofk/io_ascii.h
+++ b/SimplePofk/io_ascii.h
@@ -7,7 +7,7 @@ void process_particle_data(double *pos, int npart, double boxsize);
 // Read method for ascii
 //======================================
 
-void read_and_bin_particles_ascii(std::string filebase, int filenum, int *npart_tot, double *readbuffer, int *nbuffer){
+void read_and_bin_particles_ascii(std::string filebase, int filenum, unsigned long long *npart_tot, double *readbuffer, int *nbuffer){
   FILE *fp;
   std::string filename;
 

--- a/SimplePofk/io_gadget.h
+++ b/SimplePofk/io_gadget.h
@@ -63,7 +63,7 @@ void print_header(){
   printf("M = %e %e %e %e %e %e\n",header.mass[0],header.mass[1],header.mass[2],header.mass[3],header.mass[4],header.mass[5]);
   printf("a               = %f\n",header.time);
   printf("z               = %f\n",header.redshift);
-  printf("BoxSize (Mpc/h) = %f\n",header.BoxSize/1000.0);
+  printf("BoxSize (Mpc/h) = %f\n",header.BoxSize);
   printf("OmegaM          = %f\n",header.Omega0);
   printf("OmegaL          = %f\n",header.OmegaLambda);
   printf("HubbleParam     = %f\n",header.HubbleParam);
@@ -89,7 +89,6 @@ void read_gadget_header(FILE *fd, bool verbose = true){
 void read_gadget_float_vector(FILE *fd, void *buffer, int dim, int npart, bool verbose = true){
   int tmp;
   float *val = (float *)buffer;
-
   // Read
   my_fread(&tmp,sizeof(int),1,fd);
   my_fread(buffer, dim*sizeof(float), npart, fd);
@@ -147,7 +146,7 @@ template <typename T> std::string to_string(T value){
   return os.str();
 }
 
-void read_and_bin_particles_gadget(std::string fileprefix, int filenum, int *npart_tot, double *readbuffer, int *nbuffer){
+void read_and_bin_particles_gadget(std::string fileprefix, int filenum, unsigned long long  *npart_tot, double *readbuffer, int *nbuffer){
   std::string filename = fileprefix + to_string(filenum);
   FILE *fp;
   int npart_now;

--- a/SimplePofk/io_gadget.h
+++ b/SimplePofk/io_gadget.h
@@ -5,12 +5,38 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <algorithm>
+
+#if defined(_UNITS)
+#define units 1000.0
+#else 
+#define units 1.0
+#endif
+
+
 
 size_t my_fread(void *ptr, size_t size, size_t nmemb, FILE * stream);
 void read_gadget_float_vector(FILE *fd, void *buffer, int dim, int npart, bool print);
 void read_gadget_int_vector(FILE *fd, void *buffer, int dim, int npart, bool print);
 void read_gadget_header(FILE *fd, bool verbose);
 void process_particle_data(double *pos, int npart_now, double boxsize);
+
+//===============================================================================
+// Global boolean variable that will enable the change of endianness if necessary
+//===============================================================================
+
+  bool endianchange = false;
+
+//===================================================
+// Swap endianness 
+//================================================-===
+
+template <typename T>
+void swap_endian(T& pX)
+{
+    char& raw = reinterpret_cast<char&>(pX);
+    std::reverse(&raw, &raw + sizeof(T));
+}
 
 //=======================================================
 // Read binary method
@@ -63,11 +89,38 @@ void print_header(){
   printf("M = %e %e %e %e %e %e\n",header.mass[0],header.mass[1],header.mass[2],header.mass[3],header.mass[4],header.mass[5]);
   printf("a               = %f\n",header.time);
   printf("z               = %f\n",header.redshift);
-  printf("BoxSize (Mpc/h) = %f\n",header.BoxSize);
+  printf("BoxSize (Mpc/h) = %f\n",header.BoxSize/units);
   printf("OmegaM          = %f\n",header.Omega0);
   printf("OmegaL          = %f\n",header.OmegaLambda);
   printf("HubbleParam     = %f\n",header.HubbleParam);
   printf("======================================\n\n");
+}
+
+
+//======================================================
+// Change the endianness of the header
+//======================================================
+
+void change_endian_header(){
+  for(int i=0; i<6; i++){
+  	swap_endian(header.npart[i]);
+	swap_endian(header.mass[i]);
+	swap_endian(header.npartTotal[i]);
+	swap_endian(header.npartTotalHighWord[i]);
+	}
+  swap_endian(header.time);
+  swap_endian(header.redshift);
+  swap_endian(header.flag_sfr);
+  swap_endian(header.flag_feedback);
+  swap_endian(header.flag_cooling);
+  swap_endian(header.num_files);
+  swap_endian(header.BoxSize);
+  swap_endian(header.Omega0);
+  swap_endian(header.OmegaLambda);
+  swap_endian(header.HubbleParam);
+  swap_endian(header.flag_stellarage);
+  swap_endian(header.flag_metals);
+  swap_endian(header.flag_entropy_instead_u);
 }
 
 //=======================================================
@@ -76,9 +129,15 @@ void print_header(){
 
 void read_gadget_header(FILE *fd, bool verbose = true){
   int tmp;
-  my_fread(&tmp,sizeof(int),1,fd);
+  my_fread(&tmp,sizeof(int),1,fd); // here, if the endianness is the same as the machine we're working on, the integer should be equal to 256, i.e. number of bytes the header space reserves
+  if(tmp!=256){
+	 	endianchange = true;
+		if(verbose) std::cout << "Different endianness of the data detected! Subsequent readings will be swapped to the other endian system" << std::endl;
+			}
+
   my_fread(&header, sizeof(header), 1, fd);
   my_fread(&tmp,sizeof(int),1,fd);
+  if(endianchange) change_endian_header();
   if(verbose) print_header();
 }
 
@@ -94,8 +153,15 @@ void read_gadget_float_vector(FILE *fd, void *buffer, int dim, int npart, bool v
   my_fread(buffer, dim*sizeof(float), npart, fd);
   my_fread(&tmp,sizeof(int),1,fd);
 
+
   // Verbose
   if(verbose){
+        if(endianchange){                                                 
+		std::cout  << "???" << std::endl;
+          for(long int index = 0; index < npart*dim; index++){
+            swap_endian(val[index]);
+            }
+	  }
     std::cout << "***********************" << std::endl;
     for(int i = 0; i < npart; i++){
       if(i >= npart-10 || i <= 10){
@@ -108,7 +174,9 @@ void read_gadget_float_vector(FILE *fd, void *buffer, int dim, int npart, bool v
     }
     std::cout << "***********************" << std::endl;
     std::cout << std::endl;
+
   }
+
 }
 
 //=======================================================
@@ -123,9 +191,15 @@ void read_gadget_int_vector(FILE *fd, void *buffer, int dim, int npart, bool ver
   my_fread(&tmp,sizeof(int),1,fd);
   my_fread(buffer, dim*sizeof(int), npart, fd);
   my_fread(&tmp,sizeof(int),1,fd);
-
+   
   // Verbose
   if(verbose){
+
+        if(endianchange){
+          for(long int index = 0; index < npart*dim; index++){
+            swap_endian(val[index]);
+            }
+          }
     std::cout << "***********************" << std::endl;
     for(int i = 0; i < npart; i++){
       if(i >= npart-3 || i <= 3){
@@ -146,22 +220,23 @@ template <typename T> std::string to_string(T value){
   return os.str();
 }
 
-void read_and_bin_particles_gadget(std::string fileprefix, int filenum, unsigned long long  *npart_tot, double *readbuffer, int *nbuffer){
-  std::string filename = fileprefix + to_string(filenum);
+void read_and_bin_particles_gadget(std::string fileprefix, int filenum, unsigned long long  *npart_tot, double *readbuffer, int *nbuffer, int num_files){
+  std::string filename;;
+  if(num_files==1) filename = fileprefix ;
+  else filename = fileprefix + to_string(filenum);
   FILE *fp;
   int npart_now;
   bool verbose = false;
-
   // Open file
   std::cout << "Opening file: " << filename << std::endl;
   fp = fopen(filename.c_str(),"r");
-
+ 
   // Read header and print it for the first file only
   if(filenum==0)
     read_gadget_header(fp, true);
   else
     read_gadget_header(fp, false);
-
+  
   npart_now = header.npart[1];;
 
   // Check that buffer is large enough

--- a/SimplePofk/io_gadget.h
+++ b/SimplePofk/io_gadget.h
@@ -14,7 +14,6 @@
 #endif
 
 
-
 size_t my_fread(void *ptr, size_t size, size_t nmemb, FILE * stream);
 void read_gadget_float_vector(FILE *fd, void *buffer, int dim, int npart, bool print);
 void read_gadget_int_vector(FILE *fd, void *buffer, int dim, int npart, bool print);
@@ -28,14 +27,14 @@ void process_particle_data(double *pos, int npart_now, double boxsize);
   bool endianchange = false;
 
 //===================================================
-// Swap endianness 
+// swap_endian endianness 
 //================================================-===
 
 template <typename T>
 void swap_endian(T& pX)
 {
     char& raw = reinterpret_cast<char&>(pX);
-    std::reverse(&raw, &raw + sizeof(T));
+     std::reverse(&raw, &raw + sizeof(T));
 }
 
 //=======================================================
@@ -102,6 +101,7 @@ void print_header(){
 //======================================================
 
 void change_endian_header(){
+  
   for(int i=0; i<6; i++){
   	swap_endian(header.npart[i]);
 	swap_endian(header.mass[i]);
@@ -132,7 +132,7 @@ void read_gadget_header(FILE *fd, bool verbose = true){
   my_fread(&tmp,sizeof(int),1,fd); // here, if the endianness is the same as the machine we're working on, the integer should be equal to 256, i.e. number of bytes the header space reserves
   if(tmp!=256){
 	 	endianchange = true;
-		if(verbose) std::cout << "Different endianness of the data detected! Subsequent readings will be swapped to the other endian system" << std::endl;
+		if(verbose) std::cout << "Different endianness of the data detected! Subsequent readings will be swap_endianped to the other endian system" << std::endl;
 			}
 
   my_fread(&header, sizeof(header), 1, fd);

--- a/SimplePofk/io_gadget.h
+++ b/SimplePofk/io_gadget.h
@@ -27,7 +27,7 @@ void process_particle_data(double *pos, int npart_now, double boxsize);
   bool endianchange = false;
 
 //===================================================
-// swap_endian endianness 
+// swap endianness routine
 //================================================-===
 
 template <typename T>
@@ -132,7 +132,7 @@ void read_gadget_header(FILE *fd, bool verbose = true){
   my_fread(&tmp,sizeof(int),1,fd); // here, if the endianness is the same as the machine we're working on, the integer should be equal to 256, i.e. number of bytes the header space reserves
   if(tmp!=256){
 	 	endianchange = true;
-		if(verbose) std::cout << "Different endianness of the data detected! Subsequent readings will be swap_endianped to the other endian system" << std::endl;
+		if(verbose) std::cout << "Different endianness of the data detected! Subsequent readings will be swapped to the other endian system" << std::endl;
 			}
 
   my_fread(&header, sizeof(header), 1, fd);

--- a/SimplePofk/io_ramses.h
+++ b/SimplePofk/io_ramses.h
@@ -53,7 +53,7 @@ std::string int_to_ramses_string(int i){
 // Read method for RAMSES
 //======================================
 
-void read_and_bin_particles_ramses(std::string filebase, int filenum, int *npart_tot, double *readbuffer, int *nbuffer){
+void read_and_bin_particles_ramses(std::string filebase, int filenum, unsigned long long *npart_tot, double *readbuffer, int *nbuffer){
   FILE *fp;
   std::string filename;
 

--- a/SimplePofk/main.cpp
+++ b/SimplePofk/main.cpp
@@ -345,7 +345,7 @@ double window(int kx, int ky, int kz){
 // Assuming we have binned particles to grid
 //======================================
 void calculate_pofk(){
-  int ngrid = global.ngrid;
+  long int ngrid = global.ngrid;
   fftw_complex *grid = global.grid;
   fftw_plan *plan = &global.plan;
   double *pofk    = global.pofk;
@@ -384,9 +384,9 @@ void calculate_pofk(){
       int jj = (j < nover2 ? j : j-ngrid);
 #pragma omp parallel for 
       for(int k = 0; k < ngrid; k++){
-        long int dind = ngrid * omp_get_thread_num();
+        long long int dind = ngrid * omp_get_thread_num();
         int kk = (k < nover2 ? k : k-ngrid);
-        long long ind = i + ngrid*(j + k*ngrid);
+        long long int ind = i + ngrid*(j + k*ngrid);
         long long int kind = int(sqrt(ii*ii + jj*jj + kk*kk) + 0.5);
 
         if(kind < ngrid && kind > 0){

--- a/SimplePofk/main.cpp
+++ b/SimplePofk/main.cpp
@@ -441,7 +441,7 @@ void output_pofk(){
   ofstream pofkfile(global.pofkoutfile.c_str());
   for(int i = 1; i <= ngrid/2; i++){
     if(nmodes[i]>0){
-      pofkfile << (2*i-1)*M_PI/boxsize << " " << double(pofk[i]*boxsize*boxsize*boxsize) << endl;
+      pofkfile << (2*i+1)*M_PI/boxsize << " " << double(pofk[i]*boxsize*boxsize*boxsize) << endl;
     }
   } 
 }


### PR DESCRIPTION
Since I am using the SimplePofK for my own purposes, I wanted to be able to use the standalone program more universally.

I have:
 - changed some variable types from integer to long int / long long int due to overflow issues when trying to use NGRID > 1290 
 - added the TSC mass assignment scheme (-D_TSC) 
 - changed the normalization so that now in the output there are wavelengths [Mpc/h] and P(k) in [Mpc/h]^3
 - added the automatic endianness check and byte swap for Gadget files
 - changed the routine for reading single-chunk Gadget files - now no additional string is added to the basename
 - added the option to compile with -D_UNITS; to be used when the Gadget file is in kpc/h units
 - added a message about the minimum RAM requirement based on the grid size requested by the user